### PR TITLE
Optionally ignore max namespace ID

### DIFF
--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -88,7 +88,7 @@ func TestFuzzProveVerifyNameSpace(t *testing.T) {
 			}
 
 			if len(data) != 0 {
-				emptyProof := nmt.NewEmptyRangeProof()
+				emptyProof := nmt.NewEmptyRangeProof(false)
 				if emptyProof.VerifyNamespace(hash, nid, data, treeRoot) {
 					t.Fatalf("empty range proof on non-empty data verified to true")
 				}

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -31,7 +31,7 @@ func TestFuzzProveVerifyNameSpace(t *testing.T) {
 		nidDataMap, sortedKeys := makeRandDataAndSortedKeys(size, minNumberOfNamespaces, maxNumberOfNamespaces, minElementsPerNamespace, maxElementsPerNamespace, emptyNamespaceProbability)
 		t.Logf("Generated %v namespaces for size: %v ...", len(nidDataMap), size)
 		hash := sha256.New()
-		tree := nmt.New(hash, namespace.Size(size))
+		tree := nmt.New(hash, nmt.NamespaceIDSize(int(size)))
 
 		// push data in order:
 		for _, ns := range sortedKeys {

--- a/internal/hasher.go
+++ b/internal/hasher.go
@@ -14,14 +14,14 @@ const (
 
 type DefaultNmtHasher struct {
 	hash.Hash
-	NamespaceLen namespace.Size
+	NamespaceLen namespace.IDSize
 }
 
-func (n *DefaultNmtHasher) NamespaceSize() namespace.Size {
+func (n *DefaultNmtHasher) NamespaceSize() namespace.IDSize {
 	return n.NamespaceLen
 }
 
-func NewNmtHasher(nidLen namespace.Size, baseHasher hash.Hash) *DefaultNmtHasher {
+func NewNmtHasher(nidLen namespace.IDSize, baseHasher hash.Hash) *DefaultNmtHasher {
 	return &DefaultNmtHasher{
 		Hash:         baseHasher,
 		NamespaceLen: nidLen,

--- a/internal/hasher_test.go
+++ b/internal/hasher_test.go
@@ -38,7 +38,7 @@ func Test_namespacedTreeHasher_HashLeaf(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			n := NewNmtHasher(tt.nsLen, sha256.New())
+			n := NewNmtHasher(sha256.New(), tt.nsLen, false)
 			if got := n.HashLeaf(tt.leaf); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("HashLeaf() = %v, want %v", got, tt.want)
 			}
@@ -91,7 +91,7 @@ func Test_namespacedTreeHasher_HashNode(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			n := NewNmtHasher(tt.nidLen, sha256.New())
+			n := NewNmtHasher(sha256.New(), tt.nidLen, false)
 			if got := n.HashNode(tt.children.l, tt.children.r); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("HashNode() = %v, want %v", got, tt.want)
 			}

--- a/internal/hasher_test.go
+++ b/internal/hasher_test.go
@@ -26,7 +26,7 @@ func Test_namespacedTreeHasher_HashLeaf(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		nsLen namespace.Size
+		nsLen namespace.IDSize
 		leaf  []byte
 		want  []byte
 	}{
@@ -55,7 +55,7 @@ func Test_namespacedTreeHasher_HashNode(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		nidLen   namespace.Size
+		nidLen   namespace.IDSize
 		children children
 		want     []byte
 	}{

--- a/internal/nmt_hasher.go
+++ b/internal/nmt_hasher.go
@@ -24,5 +24,5 @@ type NmtHasher interface {
 	// Size returns the size of the underlying hasher.
 	Size() int
 	// Return the size of the namespace
-	NamespaceSize() namespace.Size
+	NamespaceSize() namespace.IDSize
 }

--- a/internal/nmt_hasher.go
+++ b/internal/nmt_hasher.go
@@ -25,4 +25,6 @@ type NmtHasher interface {
 	Size() int
 	// Return the size of the namespace
 	NamespaceSize() namespace.IDSize
+	// Returns if the NmtHasher ignores the max namespace.
+	IsMaxNamespaceIDIgnored() bool
 }

--- a/namespace/data.go
+++ b/namespace/data.go
@@ -54,7 +54,7 @@ func (d PrefixedData8) NamespaceSize() uint8 {
 }
 
 type PrefixedData struct {
-	namespaceLen Size
+	namespaceLen IDSize
 	prefixedData []byte
 }
 
@@ -66,7 +66,7 @@ func (n PrefixedData) Data() []byte {
 	return n.prefixedData[n.namespaceLen:]
 }
 
-func NewPrefixedData(namespaceLen Size, prefixedData []byte) PrefixedData {
+func NewPrefixedData(namespaceLen IDSize, prefixedData []byte) PrefixedData {
 	return PrefixedData{
 		namespaceLen: namespaceLen,
 		prefixedData: prefixedData,

--- a/namespace/digest.go
+++ b/namespace/digest.go
@@ -19,7 +19,7 @@ func NewIntervalDigest(min, max ID, digest []byte) IntervalDigest {
 // IntervalDigestFromBytes is the inverse function to IntervalDigest.Bytes().
 // In other words, it assumes that the passed in digestBytes are of the form
 // d.Min() || d.Max() || d.Hash() for an IntervalDigest d.
-func IntervalDigestFromBytes(nIDLen Size, digestBytes []byte) IntervalDigest {
+func IntervalDigestFromBytes(nIDLen IDSize, digestBytes []byte) IntervalDigest {
 	if len(digestBytes) < int(2*nIDLen) {
 		panic(fmt.Sprintf("invalid digest: %x, expected length >= %v, got: %v",
 			digestBytes, 2*nIDLen, len(digestBytes)))

--- a/namespace/digest_test.go
+++ b/namespace/digest_test.go
@@ -7,7 +7,7 @@ import (
 func TestIntervalDigestFromBytesPanic(t *testing.T) {
 	tests := []struct {
 		name        string
-		nIDLen      Size
+		nIDLen      IDSize
 		digestBytes []byte
 	}{
 		{"empty digest", 1, []byte(nil)},

--- a/namespace/id.go
+++ b/namespace/id.go
@@ -16,8 +16,8 @@ func (nid ID) LessOrEqual(other ID) bool {
 	return bytes.Compare(nid, other) <= 0
 }
 
-func (nid ID) Size() Size {
-	return Size(len(nid))
+func (nid ID) Size() IDSize {
+	return IDSize(len(nid))
 }
 func (nid ID) String() string {
 	return string(nid)

--- a/namespace/size.go
+++ b/namespace/size.go
@@ -1,5 +1,10 @@
 package namespace
 
-// Size is the number of bytes a namespace uses.
+import "math"
+
+// IDSize is the number of bytes a namespace uses.
 // Valid values are in [0,255].
-type Size uint8
+type IDSize uint8
+
+// IDMaxSize defines the max. allowed namespace ID size in bytes.
+const IDMaxSize = math.MaxUint8

--- a/nmt.go
+++ b/nmt.go
@@ -24,8 +24,9 @@ var (
 )
 
 type Options struct {
-	InitialCapacity int
-	NamespaceIDSize namespace.IDSize
+	InitialCapacity    int
+	NamespaceIDSize    namespace.IDSize
+	IgnoreMaxNamespace bool
 }
 
 type Option func(*Options)
@@ -49,6 +50,16 @@ func NamespaceIDSize(size int) Option {
 	}
 	return func(opts *Options) {
 		opts.NamespaceIDSize = namespace.IDSize(size)
+	}
+}
+
+// IgnoreMaxNamespace sets whether the largest possible namespace.ID MAX_NID should be 'ignored'.
+// If set to true, this allows for shorter proofs in particular use-cases.
+// E.g., see: https://github.com/lazyledger/lazyledger-specs/blob/master/specs/data_structures.md#namespace-merkle-tree
+// Defaults to false.
+func IgnoreMaxNamespace(ignore bool) Option {
+	return func(opts *Options) {
+		opts.IgnoreMaxNamespace = ignore
 	}
 }
 

--- a/nmt.go
+++ b/nmt.go
@@ -56,7 +56,7 @@ func NamespaceIDSize(size int) Option {
 // IgnoreMaxNamespace sets whether the largest possible namespace.ID MAX_NID should be 'ignored'.
 // If set to true, this allows for shorter proofs in particular use-cases.
 // E.g., see: https://github.com/lazyledger/lazyledger-specs/blob/master/specs/data_structures.md#namespace-merkle-tree
-// Defaults to false.
+// Defaults to true.
 func IgnoreMaxNamespace(ignore bool) Option {
 	return func(opts *Options) {
 		opts.IgnoreMaxNamespace = ignore
@@ -86,7 +86,7 @@ func New(h hash.Hash, setters ...Option) *NamespacedMerkleTree {
 	opts := &Options{
 		InitialCapacity:    128,
 		NamespaceIDSize:    32,
-		IgnoreMaxNamespace: false,
+		IgnoreMaxNamespace: true,
 	}
 
 	for _, setter := range setters {

--- a/nmt_test.go
+++ b/nmt_test.go
@@ -322,6 +322,9 @@ func TestIgnoreMaxNamespace(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ProveNamespace() unexpected error: %v", err)
 		}
+		if !proof.IsMaxNamespaceIDIgnored() {
+			t.Fatalf("Proof.IsMaxNamespaceIDIgnored() got: false, want: true")
+		}
 		data := tree.Get(d.NamespaceID())
 		if !proof.VerifyNamespace(hash, d.NamespaceID(), data, tree.Root()) {
 			t.Errorf("VerifyNamespace() failed on ID: %x", d.NamespaceID())
@@ -333,6 +336,9 @@ func TestIgnoreMaxNamespace(t *testing.T) {
 		}
 		if !singleProof.VerifyInclusion(hash, d, tree.Root()) {
 			t.Errorf("VerifyInclusion() failed on data: %#v with index: %v", d, idx)
+		}
+		if !singleProof.IsMaxNamespaceIDIgnored() {
+			t.Fatalf("Proof.IsMaxNamespaceIDIgnored() got: false, want: true")
 		}
 	}
 }

--- a/nmt_test.go
+++ b/nmt_test.go
@@ -317,6 +317,24 @@ func TestIgnoreMaxNamespace(t *testing.T) {
 	if !gotDigest.Max().Equal(wantMaxNID) {
 		t.Fatalf("Unexpected root.Max() got: %x, want: %x", gotDigest.Max(), wantMaxNID)
 	}
+	for idx, d := range data {
+		proof, err := tree.ProveNamespace(d.NamespaceID())
+		if err != nil {
+			t.Fatalf("ProveNamespace() unexpected error: %v", err)
+		}
+		data := tree.Get(d.NamespaceID())
+		if !proof.VerifyNamespace(hash, d.NamespaceID(), data, tree.Root()) {
+			t.Errorf("VerifyNamespace() failed on ID: %x", d.NamespaceID())
+		}
+
+		singleProof, err := tree.Prove(idx)
+		if err != nil {
+			t.Fatalf("ProveNamespace() unexpected error: %v", err)
+		}
+		if !singleProof.VerifyInclusion(hash, d, tree.Root()) {
+			t.Errorf("VerifyInclusion() failed on data: %#v with index: %v", d, idx)
+		}
+	}
 }
 
 func TestNamespacedMerkleTree_ProveErrors(t *testing.T) {

--- a/nmt_test.go
+++ b/nmt_test.go
@@ -408,6 +408,18 @@ func TestNamespacedMerkleTree_calculateAbsenceIndex_Panic(t *testing.T) {
 	}
 }
 
+func TestInvalidOptions(t *testing.T) {
+	shouldPanic(t, func() {
+		_ = New(sha256.New(), InitialCapacity(-1))
+	})
+	shouldPanic(t, func() {
+		_ = New(sha256.New(), NamespaceIDSize(-1))
+	})
+	shouldPanic(t, func() {
+		_ = New(sha256.New(), NamespaceIDSize(namespace.IDMaxSize+1))
+	})
+}
+
 func shouldPanic(t *testing.T, f func()) {
 	//nolint:errcheck
 	defer func() { recover() }()

--- a/nmt_test.go
+++ b/nmt_test.go
@@ -305,8 +305,12 @@ func TestIgnoreMaxNamespace(t *testing.T) {
 	}
 
 	tree := New(hash, NamespaceIDSize(nidSize), IgnoreMaxNamespace(true))
+	treeNotIgnoredOpt := New(hash, NamespaceIDSize(nidSize), IgnoreMaxNamespace(false))
 	for _, d := range data {
 		if err := tree.Push(d); err != nil {
+			panic("unexpected error")
+		}
+		if err := treeNotIgnoredOpt.Push(d); err != nil {
 			panic("unexpected error")
 		}
 	}
@@ -316,6 +320,11 @@ func TestIgnoreMaxNamespace(t *testing.T) {
 	}
 	if !gotDigest.Max().Equal(wantMaxNID) {
 		t.Fatalf("Unexpected root.Max() got: %x, want: %x", gotDigest.Max(), wantMaxNID)
+	}
+	// if we explicitly do not ignore the max namespace, we expect it to show up in the root:
+	gotDigest2 := treeNotIgnoredOpt.Root()
+	if !gotDigest2.Max().Equal(maxNID) {
+		t.Fatalf("Unexpected root.Max() got: %x, want: %x", gotDigest2.Max(), maxNID)
 	}
 	for idx, d := range data {
 		proof, err := tree.ProveNamespace(d.NamespaceID())

--- a/proof_test.go
+++ b/proof_test.go
@@ -28,7 +28,7 @@ func TestProof_VerifyNamespace_False(t *testing.T) {
 	if err != nil {
 		t.Fatalf("invalid test setup: error on ProveNamespace(): %v", err)
 	}
-	incompleteFirstNs := NewInclusionProof(0, 1, rangeProof(t, n, 0, 1))
+	incompleteFirstNs := NewInclusionProof(0, 1, rangeProof(t, n, 0, 1), false)
 	type args struct {
 		nID  namespace.ID
 		data []namespace.Data
@@ -54,13 +54,13 @@ func TestProof_VerifyNamespace_False(t *testing.T) {
 		{"remove one leaf, errors", validProof,
 			args{[]byte{0, 0, 0}, pushedZeroNs[:len(pushedZeroNs)-1], n.Root()},
 			false},
-		{"remove one leaf & update proof range, errors", NewInclusionProof(validProof.Start(), validProof.End()-1, validProof.Nodes()),
+		{"remove one leaf & update proof range, errors", NewInclusionProof(validProof.Start(), validProof.End()-1, validProof.Nodes(), false),
 			args{[]byte{0, 0, 0}, pushedZeroNs[:len(pushedZeroNs)-1], n.Root()},
 			false},
 		{"incomplete namespace proof (right)", incompleteFirstNs,
 			args{[]byte{0, 0, 0}, pushedZeroNs[:len(pushedZeroNs)-1], n.Root()},
 			false},
-		{"incomplete namespace proof (left)", NewInclusionProof(10, 11, rangeProof(t, n, 10, 11)),
+		{"incomplete namespace proof (left)", NewInclusionProof(10, 11, rangeProof(t, n, 10, 11), false),
 			args{[]byte{0, 0, 8}, pushedLastNs[1:], n.Root()},
 			false},
 		{"remove all leaves, errors", validProof,

--- a/proof_test.go
+++ b/proof_test.go
@@ -12,7 +12,7 @@ import (
 func TestProof_VerifyNamespace_False(t *testing.T) {
 	const testNidLen = 3
 
-	n := New(sha256.New(), testNidLen)
+	n := New(sha256.New(), NamespaceIDSize(testNidLen))
 	data := append(append([]namespace.PrefixedData{
 		namespace.PrefixedDataFrom([]byte{0, 0, 0}, []byte("first leaf"))},
 		generateLeafData(testNidLen, 0, 9, []byte("data"))...,


### PR DESCRIPTION
implements and closes #8 

Also tackles setting the init. capacity for internal slices as an option (see comment/discussion: https://github.com/lazyledger/nmt/pull/3#discussion_r467980031)