### PR TITLE
remove obsolete method Data.NamespaceSize

### DIFF
--- a/namespace/data.go
+++ b/namespace/data.go
@@ -21,10 +21,6 @@ func (d PrefixedData32) Data() []byte {
 	return d[32:]
 }
 
-func (d PrefixedData32) NamespaceSize() uint8 {
-	return 32
-}
-
 type PrefixedData16 []byte
 
 func (d PrefixedData16) NamespaceID() ID {
@@ -35,10 +31,6 @@ func (d PrefixedData16) Data() []byte {
 	return d[16:]
 }
 
-func (d PrefixedData16) NamespaceSize() uint8 {
-	return 16
-}
-
 type PrefixedData8 []byte
 
 func (d PrefixedData8) NamespaceID() ID {
@@ -47,10 +39,6 @@ func (d PrefixedData8) NamespaceID() ID {
 
 func (d PrefixedData8) Data() []byte {
 	return d[8:]
-}
-
-func (d PrefixedData8) NamespaceSize() uint8 {
-	return 8
 }
 
 type PrefixedData struct {


### PR DESCRIPTION
Instead the ID returned by the data has a size, hence Data.ID().Size() is used everywhere anyways