### PR TITLE
Implement Equal for IntervalDigest

### DIFF
--- a/namespace/digest.go
+++ b/namespace/digest.go
@@ -1,6 +1,9 @@
 package namespace
 
-import "fmt"
+import (
+	"bytes"
+	"fmt"
+)
 
 type IntervalDigest struct {
 	min    ID
@@ -38,6 +41,10 @@ func (d IntervalDigest) Hash() []byte {
 
 func (d IntervalDigest) Bytes() []byte {
 	return append(append(d.min, d.max...), d.digest...)
+}
+
+func (d *IntervalDigest) Equal(to *IntervalDigest) bool {
+	return d.max.Equal(to.max) && d.min.Equal(to.min) && bytes.Equal(d.digest, to.digest)
 }
 
 func (d IntervalDigest) String() string {

--- a/namespace/digest_test.go
+++ b/namespace/digest_test.go
@@ -54,3 +54,31 @@ func TestIntervalDigest_String(t *testing.T) {
 		})
 	}
 }
+
+func TestIntervalDigest_Equal(t *testing.T) {
+	tests := []struct {
+		name     string
+		one, two *IntervalDigest
+		want     bool
+	}{
+		{
+			"equal",
+			&IntervalDigest{[]byte{0}, []byte{1}, []byte{}},
+			&IntervalDigest{[]byte{0}, []byte{1}, []byte{}},
+			true,
+		},
+		{
+			"unequal",
+			&IntervalDigest{[]byte{0}, []byte{1}, []byte{1, 0, 0}},
+			&IntervalDigest{[]byte{0}, []byte{1}, []byte{1, 1, 1}},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.one.Equal(tt.two); got != tt.want {
+				t.Errorf("Equal() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Otherwise, a user has to implement it himself using Bytes() what would cause him to make unnecessary allocations