### PR TITLE
Make `IntervalDigest` jsonable

### DIFF
--- a/namespace/digest.go
+++ b/namespace/digest.go
@@ -6,9 +6,9 @@ import (
 )
 
 type IntervalDigest struct {
-	min    ID
-	max    ID
-	digest []byte
+	Min    ID     `json:"max"`
+	Max    ID     `json:"min"`
+	Digest []byte `json:"digest"`
 }
 
 // IntervalDigestFromBytes is the inverse function to IntervalDigest.Bytes().
@@ -21,34 +21,26 @@ func IntervalDigestFromBytes(nIDLen IDSize, digestBytes []byte) (IntervalDigest,
 	}
 
 	return IntervalDigest{
-		min:    digestBytes[:nIDLen],
-		max:    digestBytes[nIDLen : 2*nIDLen],
-		digest: digestBytes[2*nIDLen:],
+		Min:    digestBytes[:nIDLen],
+		Max:    digestBytes[nIDLen : 2*nIDLen],
+		Digest: digestBytes[2*nIDLen:],
 	}, nil
 }
 
-func (d IntervalDigest) Min() ID {
-	return d.min
-}
-
-func (d IntervalDigest) Max() ID {
-	return d.max
-}
-
 func (d IntervalDigest) Hash() []byte {
-	return d.digest
+	return d.Digest
 }
 
 func (d IntervalDigest) Bytes() []byte {
 	return append(append(append(
-		make([]byte, 0, len(d.min)*2+len(d.digest)),
-		d.min...),
-		d.max...),
-		d.digest...)
+		make([]byte, 0, len(d.Min)*2+len(d.Digest)),
+		d.Min...),
+		d.Max...),
+		d.Digest...)
 }
 
 func (d *IntervalDigest) Equal(to *IntervalDigest) bool {
-	return d.max.Equal(to.max) && d.min.Equal(to.min) && bytes.Equal(d.digest, to.digest)
+	return d.Max.Equal(to.Max) && d.Min.Equal(to.Min) && bytes.Equal(d.Digest, to.Digest)
 }
 
 func (d IntervalDigest) String() string {
@@ -57,5 +49,5 @@ func (d IntervalDigest) String() string {
   min: %x
   max: %x
   digest: %x
-}`, d.min, d.max, d.digest)
+}`, d.Min, d.Max, d.Digest)
 }

--- a/namespace/digest.go
+++ b/namespace/digest.go
@@ -6,8 +6,8 @@ import (
 )
 
 type IntervalDigest struct {
-	Min    ID     `json:"max"`
-	Max    ID     `json:"min"`
+	Min    ID     `json:"min"`
+	Max    ID     `json:"max"`
 	Digest []byte `json:"digest"`
 }
 

--- a/namespace/digest_test.go
+++ b/namespace/digest_test.go
@@ -44,9 +44,9 @@ func TestIntervalDigest_String(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := IntervalDigest{
-				min:    tt.fields.min,
-				max:    tt.fields.max,
-				digest: tt.fields.digest,
+				Min:    tt.fields.min,
+				Max:    tt.fields.max,
+				Digest: tt.fields.digest,
 			}
 			if got := d.String(); got != tt.want {
 				t.Errorf("String() = %v, want %v", got, tt.want)

--- a/nmt_test.go
+++ b/nmt_test.go
@@ -54,11 +54,11 @@ func ExampleNamespacedMerkleTree() {
 	// compute the root
 	root := tree.Root()
 	// the root's min/max namespace is the min and max namespace of all leaves:
-	if root.Min().Equal(namespace.ID{0}) {
-		fmt.Printf("Min namespace: %x\n", root.Min())
+	if root.Min.Equal(namespace.ID{0}) {
+		fmt.Printf("Min namespace: %x\n", root.Min)
 	}
-	if root.Max().Equal(namespace.ID{1}) {
-		fmt.Printf("Max namespace: %x\n", root.Max())
+	if root.Max.Equal(namespace.ID{1}) {
+		fmt.Printf("Max namespace: %x\n", root.Max)
 	}
 
 	// compute proof for namespace 0:
@@ -154,7 +154,7 @@ func TestNamespacedMerkleTreeRoot(t *testing.T) {
 				}
 			}
 			root := n.Root()
-			gotMinNs, gotMaxNs, gotRoot := root.Min(), root.Max(), root.Hash()
+			gotMinNs, gotMaxNs, gotRoot := root.Min, root.Max, root.Hash()
 			if !reflect.DeepEqual(gotMinNs, tt.wantMinNs) {
 				t.Errorf("Root() gotMinNs = %v, want %v", gotMinNs, tt.wantMinNs)
 			}
@@ -440,7 +440,7 @@ func TestIgnoreMaxNamespace(t *testing.T) {
 					panic("unexpected error")
 				}
 			}
-			gotRootMaxNID := tree.Root().Max()
+			gotRootMaxNID := tree.Root().Max
 			if !gotRootMaxNID.Equal(tc.wantRootMaxNID) {
 				t.Fatalf("Case: %v, '%v', root.Max() got: %x, want: %x", i, tc.name, gotRootMaxNID, tc.wantRootMaxNID)
 			}
@@ -495,10 +495,10 @@ func TestNodeVisitor(t *testing.T) {
 	if !bytes.Equal(root.Hash(), last[nidSize*2:]) {
 		t.Fatalf("last visited node's digest does not match the tree root's.")
 	}
-	if !bytes.Equal(root.Min(), last[:nidSize]) {
+	if !bytes.Equal(root.Min, last[:nidSize]) {
 		t.Fatalf("last visited node's min namespace does not match the tree root's.")
 	}
-	if !bytes.Equal(root.Max(), last[nidSize:nidSize*2]) {
+	if !bytes.Equal(root.Max, last[nidSize:nidSize*2]) {
 		t.Fatalf("last visited node's max namespace does not match the tree root's.")
 	}
 	t.Log("printing nodes in visiting order") // postorder DFS

--- a/proof.go
+++ b/proof.go
@@ -98,7 +98,7 @@ func NewAbsenceProof(proofStart, proofEnd int, proofNodes [][]byte, leafHash []b
 // is complete and no leaf of that namespace was left out in the proof.
 func (proof Proof) VerifyNamespace(h hash.Hash, nID namespace.ID, data [][]byte, root namespace.IntervalDigest) bool {
 	nth := NewNmtHasher(h, nID.Size(), proof.isMaxNamespaceIDIgnored)
-	if nID.Size() != root.Min().Size() || nID.Size() != root.Max().Size() {
+	if nID.Size() != root.Min.Size() || nID.Size() != root.Max.Size() {
 		// conflicting namespace sizes
 		return false
 	}
@@ -183,7 +183,7 @@ func (proof Proof) verifyLeafHashes(nth *Hasher, verifyCompleteness bool, nID na
 	if verifyCompleteness {
 		// leftSubtrees contains the subtree roots upto [0, r.Start)
 		for _, subtree := range leftSubtrees {
-			leftSubTreeMax := mustIntervalDigestFromBytes(nth.NamespaceSize(), subtree).Max()
+			leftSubTreeMax := mustIntervalDigestFromBytes(nth.NamespaceSize(), subtree).Max
 			if nID.LessOrEqual(leftSubTreeMax) {
 				return false
 			}
@@ -191,7 +191,7 @@ func (proof Proof) verifyLeafHashes(nth *Hasher, verifyCompleteness bool, nID na
 		// rightSubtrees only contains the subtrees after [0, r.Start)
 		rightSubtrees := proof.nodes
 		for _, subtree := range rightSubtrees {
-			rightSubTreeMin := mustIntervalDigestFromBytes(nth.NamespaceSize(), subtree).Min()
+			rightSubTreeMin := mustIntervalDigestFromBytes(nth.NamespaceSize(), subtree).Min
 			if rightSubTreeMin.LessOrEqual(nID) {
 				return false
 			}


### PR DESCRIPTION
Some [tests](https://github.com/lazyledger/lazyledger-core/blob/59ceaf8c44a069a55d5f8f8f3bea50b23a186146/rpc/client/evidence_test.go#L115) in lazyledger-core require `DataAvailabilityHeader` to be encoded via json, this PR exports the fields of IntervalDigest, along with adding appropriate json tags.

This PR, or another alternative, should be merged before [#312](https://github.com/lazyledger/lazyledger-core/pull/312) can be merged.

closes #34